### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # MCP Server - JavaScript SDK
+[![smithery badge](https://smithery.ai/badge/mcp-js-server)](https://smithery.ai/server/mcp-js-server)
 
 This is an unofficial JavaScript SDK for [Model Context Protocol](https://spec.modelcontextprotocol.io/latest).
+
+### Installing via Smithery
+
+To install mcp-js-server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-js-server):
+
+```bash
+npx -y @smithery/cli install mcp-js-server --client claude
+```
 
 ## Usage
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install mcp-js-server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-js-server

Let me know if any tweaks have to be made!